### PR TITLE
use abstract superclass for param errors

### DIFF
--- a/src/prism/action/params.cr
+++ b/src/prism/action/params.cr
@@ -69,7 +69,7 @@ module Prism
         before do
           begin
             @params = self.class.parse_params(context, self.class.max_body_size, @@preserve_body)
-          rescue ex : InvalidParamTypeError | ParamNotFoundError | InvalidParamError | ProcError
+          rescue ex : ParamError
             context.response.status_code = 422
             context.response.print(ex.message)
           end

--- a/src/prism/channel/params.cr
+++ b/src/prism/channel/params.cr
@@ -35,7 +35,7 @@ module Prism
           begin
             @params = self.class.parse_params(context)
             true
-          rescue ex : InvalidParamTypeError | ParamNotFoundError | InvalidParamError | ProcError
+          rescue ex : ParamError
             socket.close(ex.message)
             false
           end


### PR DESCRIPTION
this allows type safe rescuing