### PR TITLE
Replace google fonts

### DIFF
--- a/src/onyx-http/middleware/renderer/rest_error.html.ecr
+++ b/src/onyx-http/middleware/renderer/rest_error.html.ecr
@@ -3,12 +3,11 @@
 <head>
   <title><%= error.is_a?(Error) ? error.status_message : ::HTTP::Status.new(500).description %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-  <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet">
   <style type="text/css">
     html, body {
       margin: 0;
       padding: 0;
-      font-family: "Source Sans Pro", sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
     }
 
     body {


### PR DESCRIPTION
As a user of the framework, I expect for the error page template _not_ to reach out for external internet resources by default.

Instead of a webfont, I suggest using the same native font stack as specified by the exception page: https://github.com/crystal-loot/exception_page/blob/063e8106201d526b0c716f68de036864e723ff22/src/exception_page/exception_page.ecr#L30

## Before
![00-before](https://user-images.githubusercontent.com/3905798/63653580-b29b5400-c73c-11e9-8545-97eec4cc3e6f.png)

## After
![01-after](https://user-images.githubusercontent.com/3905798/63653581-b29b5400-c73c-11e9-8fd6-e7c840c87206.png)

